### PR TITLE
Switch from hostname to fqdn.

### DIFF
--- a/boundary_riskapi_plugin/plugin.py
+++ b/boundary_riskapi_plugin/plugin.py
@@ -8,8 +8,8 @@ import urllib
 import logging
 log = logging.getLogger(__name__)
 
-HOSTNAME = socket.gethostname()
-POLL_INTERVAL = 5000
+HOSTNAME = socket.getfqdn()
+POLL_INTERVAL = 1000
 
 BASE_URL = "localhost"
 PORT = "5565"

--- a/plugin.json
+++ b/plugin.json
@@ -45,7 +45,7 @@
       "name": "riskapi_poll_interval",
       "description": "Interval between sends (milliseconds)",
       "type": "integer",
-      "default": "5000",
+      "default": "1000",
       "required": true
     }
   ]


### PR DESCRIPTION
Default hostname is now the host's fqdn. Also, poll interval now defaults to 1 second instead of 5.